### PR TITLE
Update to support Twitter API V1.1

### DIFF
--- a/SimpleSocialSharing/src/com/nostra13/socialsharing/twitter/extpack/winterwell/jtwitter/Twitter.java
+++ b/SimpleSocialSharing/src/com/nostra13/socialsharing/twitter/extpack/winterwell/jtwitter/Twitter.java
@@ -693,7 +693,7 @@ public class Twitter implements Serializable {
 	 * API. <br>
 	 * Note: Does not include the final "/"
 	 */
-	String TWITTER_URL = "http://api.twitter.com/1";
+	String TWITTER_URL = "http://api.twitter.com/1.1";
 
 	private Date untilDate;
 


### PR DESCRIPTION
Twitter discontinued API V1 from June 11,2013. This update makes it compatible for V1.1
